### PR TITLE
Fix web worker setup

### DIFF
--- a/lib/webclient/index.js
+++ b/lib/webclient/index.js
@@ -13,25 +13,26 @@ const INITIAL_ID = 100;
 
 /**
  * create new webworker API interface
+ * @param {Worker} [worker] Optional worker instance
  */
-function initialiseWebworkerAPI() {
-  return new WebWorkerApi();
+function initialiseWebworkerAPI(worker) {
+  return new WebWorkerApi(worker);
 }
 
 class WebWorkerApi {
 
   /**
    * Create the web worker API
-   * @param {Worker} [webworker] Optional worker instance
+   * @param {Worker} [worker] Optional worker instance
    */
-  constructor(webworker) {
-    if (!webworker && !window.Worker) {
+  constructor(worker) {
+    if (!worker && !window.Worker) {
       throw new Error('NO_WEBWORKER_SUPPORT');
     }
 
     this.id = INITIAL_ID;
     this.rpcProxy = RpcProxy.build();
-    this.worker = webworker || new Worker('webworker.js');
+    this.worker = worker || new Worker('webworker.js');
 
     this.worker.onmessage = (message = {}) => {
       const messageData = message.data;

--- a/lib/webclient/index.js
+++ b/lib/webclient/index.js
@@ -20,14 +20,18 @@ function initialiseWebworkerAPI() {
 
 class WebWorkerApi {
 
-  constructor() {
-    if (!window.Worker) {
+  /**
+   * Create the web worker API
+   * @param {Worker} [webworker] Optional worker instance
+   */
+  constructor(webworker) {
+    if (!webworker && !window.Worker) {
       throw new Error('NO_WEBWORKER_SUPPORT');
     }
 
     this.id = INITIAL_ID;
     this.rpcProxy = RpcProxy.build();
-    this.worker = new Worker('webworker.js');
+    this.worker = webworker || new Worker('webworker.js');
 
     this.worker.onmessage = (message = {}) => {
       const messageData = message.data;


### PR DESCRIPTION
This allows bundling the web worker in third-party clients by passing a worker instance to the initialize function of the WPC API.

A Webpack setup would look like this:

1. Install [worker-loader](https://github.com/webpack-contrib/worker-loader): `npm install worker-loader --save-dev`
2. Import and instantiate the worker:
   ```js
   import Worker from 'worker-loader!wpc-emu/lib/webclient/webworker.js';
   const wpcEmuWebWorkerApi = WpcEmuWebWorkerApi.initialiseWebworkerAPI(new Worker());
   // wpc api available!
   ```
   
Note that you don't need a separate entry point for the worker when building with Webpack anymore. 

This patch is backwards-compatible.