### PR TITLE
Improve DMD dump

### DIFF
--- a/client/scripts/lib/pin2DmdExport.js
+++ b/client/scripts/lib/pin2DmdExport.js
@@ -48,7 +48,7 @@ class DmdGrabber {
 
   constructor() {
     this.frames = [ HEADER ];
-    this.lastVideoOutputBuffer = [];
+    this.lastVideoCaptureTicks = -1;
   }
 
   _ticksToTimestamp(ticks) {
@@ -61,11 +61,12 @@ class DmdGrabber {
     ];
   }
 
-  addFrames(videoOutputBuffer, ticks) {
-    if (arraysEqual(this.lastVideoOutputBuffer, videoOutputBuffer)) {
+  addFrames(videoOutputBuffer, videoCaptureTicks) {
+    if (this.lastVideoCaptureTicks === videoCaptureTicks) {
       return;
     }
-    const timeSinceLastFrameMs = this._ticksToTimestamp(ticks);
+    this.lastVideoCaptureTicks = videoCaptureTicks;
+    const timeSinceLastFrameMs = this._ticksToTimestamp(videoCaptureTicks);
     this.lastVideoOutputBuffer = videoOutputBuffer;
     this.frames.push(
       timeSinceLastFrameMs.concat(Array.from(videoOutputBuffer))
@@ -83,19 +84,4 @@ class DmdGrabber {
 
 function flatten(array) {
   return Array.prototype.concat(...array);
-}
-
-function arraysEqual(a, b) {
-  if (a === b) {
-    return true;
-  }
-  if (a === null || b === null || a.length !== b.length) {
-    return false;
-  }
-  for (let i = 0; i < a.length; ++i) {
-    if (a[i] !== b[i]) {
-      return false;
-    }
-  }
-  return true;
 }

--- a/client/scripts/main.js
+++ b/client/scripts/main.js
@@ -97,7 +97,7 @@ function initializeEmu(gameEntry) {
           }
 
           if (dmdDump) {
-            dmdDump.addFrames(emuState.asic.dmd.videoOutputBuffer, emuState.cpuState.tickCount);
+            dmdDump.addFrames(emuState.asic.dmd.videoOutputBuffer, emuState.asic.dmd.videoCaptureTicks);
 
             const capturedFrames = dmdDump.getCapturedFrames();
             if (capturedFrames > MAXIMAL_DMD_FRAMES_TO_RIP) {

--- a/lib/boards/elements/output-dmd-display.js
+++ b/lib/boards/elements/output-dmd-display.js
@@ -53,9 +53,9 @@ function getInstance(dmdPageSize) {
 class OutputDmdDisplay {
   constructor(dmdPageSize) {
     this.dmdPageSize = dmdPageSize;
-    this.shadedVideoBuffer = new Uint8Array(dmdPageSize * DMD_SHADING_FRAMES).fill(0);
-    this.shadedVideoBufferLatched = new Uint8Array(dmdPageSize * DMD_SHADING_FRAMES).fill(0);
-    this.videoRam = new Uint8Array(dmdPageSize * DMD_NR_OF_PAGES).fill(0);
+    this.shadedVideoBuffer = new Uint8Array(dmdPageSize * DMD_SHADING_FRAMES);
+    this.shadedVideoBufferLatched = new Uint8Array(dmdPageSize * DMD_SHADING_FRAMES);
+    this.videoRam = new Uint8Array(dmdPageSize * DMD_NR_OF_PAGES);
 
     this.dmdPageMapping = [ 0, 0, 0, 0, 0, 0 ];
     this.scanline = 0;
@@ -169,7 +169,7 @@ class OutputDmdDisplay {
     const OFFSET_BUFFER1 = this.dmdPageSize;
     const OFFSET_BUFFER2 = this.dmdPageSize * 2;
     // output is 8 times larger (1 pixel uses 1 byte)
-    const videoBufferShaded = new Uint8Array(8 * this.dmdPageSize).fill(0);
+    const videoBufferShaded = new Uint8Array(8 * this.dmdPageSize);
 
     let outputOffset = 0;
     let inputOffset = 0;

--- a/lib/boards/elements/output-dmd-display.js
+++ b/lib/boards/elements/output-dmd-display.js
@@ -56,6 +56,7 @@ class OutputDmdDisplay {
     this.shadedVideoBuffer = new Uint8Array(dmdPageSize * DMD_SHADING_FRAMES);
     this.shadedVideoBufferLatched = new Uint8Array(dmdPageSize * DMD_SHADING_FRAMES);
     this.videoRam = new Uint8Array(dmdPageSize * DMD_NR_OF_PAGES);
+    this.referenceVideoBuffer = this.shadedVideoBufferLatched;
 
     this.dmdPageMapping = [ 0, 0, 0, 0, 0, 0 ];
     this.scanline = 0;
@@ -64,12 +65,15 @@ class OutputDmdDisplay {
     this.videoOutputPointer = 0;
     this.requestFIRQ = true;
     this.ticksUpdateDmd = 0;
+    this.videoTicksCounter = 0;
+    this.videoCaptureTicks = 0; // When was the reference buffer last captured
   }
 
   executeCycle(singleTicks) {
     this.ticksUpdateDmd += singleTicks;
     if (this.ticksUpdateDmd >= timing.CALL_WPC_UPDATE_DISPLAY_AFTER_TICKS) {
       this.ticksUpdateDmd -= timing.CALL_WPC_UPDATE_DISPLAY_AFTER_TICKS;
+      this.videoTicksCounter += timing.CALL_WPC_UPDATE_DISPLAY_AFTER_TICKS;
       this._copyScanline();
       return {
         requestFIRQ: this.requestFIRQ,
@@ -89,9 +93,10 @@ class OutputDmdDisplay {
       // NOTE: this might flicker, as video ram is not double buffered
       videoRam: this.videoRam,
       // use cached image, used to dump dmd frames
-      videoOutputBuffer: this.shadedVideoBuffer,
+      videoOutputBuffer: this.referenceVideoBuffer,
       videoOutputPointer: this.videoOutputPointer,
       ticksUpdateDmd: this.ticksUpdateDmd,
+      videoCaptureTicks: this.videoCaptureTicks,
     };
   }
 
@@ -140,7 +145,7 @@ class OutputDmdDisplay {
   _copyScanline() {
     // copy a scanline from the activePage to the output video buffer
     const sourceAddress = this.activePage * this.dmdPageSize + this.scanline * DMD_SCANLINE_SIZE_IN_BYTES;
-    const destinationAddress = this.videoOutputPointer * this.dmdPageSize + this.scanline * DMD_SCANLINE_SIZE_IN_BYTES;
+    const destinationAddress = (DMD_SHADING_FRAMES - 1) * this.dmdPageSize + this.scanline * DMD_SCANLINE_SIZE_IN_BYTES;
     for (let i = 0; i < DMD_SCANLINE_SIZE_IN_BYTES; i++) {
       this.shadedVideoBuffer[destinationAddress + i] = this.videoRam[sourceAddress + i];
     }
@@ -154,11 +159,37 @@ class OutputDmdDisplay {
       this.videoOutputPointer = (this.videoOutputPointer + 1) % DMD_SHADING_FRAMES;
       this.shadedVideoBufferLatched = new Uint8Array(this.shadedVideoBuffer);
 
+      // Every third frame, compare with the reference and capture if changed
+      if (this.videoOutputPointer === 0) {
+        if (!this.arraysEqual(this.referenceVideoBuffer, this.shadedVideoBufferLatched)) {
+          this.videoCaptureTicks = this.videoTicksCounter;
+          this.referenceVideoBuffer = this.shadedVideoBufferLatched;
+        }
+      }
+
+      // Shift frames down to make room for a new frame
+      this.shadedVideoBuffer.copyWithin(0, this.dmdPageSize);
+
       if (Number.isInteger(this.nextActivePage)) {
         this.activePage = this.nextActivePage;
         this.nextActivePage = undefined;
       }
     }
+  }
+
+  arraysEqual(a, b) {
+    if (a === b) {
+      return true;
+    }
+    if (a === null || b === null || a.length !== b.length) {
+      return false;
+    }
+    for (let i = 0; i < a.length; ++i) {
+      if (a[i] !== b[i]) {
+        return false;
+      }
+    }
+    return true;
   }
 
   // a pixel can have 0%/33%/66%/100% Intensity depending on the display time the last 3 frames

--- a/lib/boards/ui.js
+++ b/lib/boards/ui.js
@@ -165,6 +165,7 @@ class UiState {
         nextActivePage: state.display.nextActivePage,
         requestFIRQ: state.display.requestFIRQ,
         ticksUpdateDmd: state.display.ticksUpdateDmd,
+        videoCaptureTicks: state.display.videoCaptureTicks,
       },
     };
   }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -320,6 +320,7 @@ export namespace WpcEmuWebWorkerApi {
     nextActivePage?: number;
     requestFIRQ?: boolean;
     ticksUpdateDmd?: number;
+    videoCaptureTicks?: number;
   }
 
   interface EmuStateAsic {


### PR DESCRIPTION
Hello!

The current DMD dump has several flaws that makes the dumped data divert from what a pinball display would actually receive:
- Data is dumped asynchronously from the video buffer as it is updated leading to partially drawn frames.
- Round robin buffering saves the frames in a different order to how they should be displayed.
- The time stamp is not representative of when frames would be output to a real display.

Here is the output of a simple dump visualization tool I put together:
![image](https://github.com/user-attachments/assets/d4cddb4a-e41e-462d-8431-46f5a1f858b3)
1 - Partially drawn frame.
2 & 3 - Partially drawn frames in the wrong order, these should come last in the set of three.

Timestamps are always a multiple of 20 ms which is the rate the main thread grabs frames, but the true timing of three frames is 24.576 ms. If the main thread captured faster it would even risk outputting the same frame multiple times.

This PR moves the responsibility to detect new frames together with timing into output-dmd-display.js. Buffering is also changed from round robin to a queue, frames are always placed last in the shadedVideoBuffer buffer to preserve order.

With the patch applied a dump of the same sequence looks like this:
![image](https://github.com/user-attachments/assets/60da6cb1-dcb3-4684-8ae3-b53ab9d908b2)

No more partial frames, transitions between scenes are crisp, and the time stamps now increase according to the true display frame rate (with some rounding).

A potential performance improvement is to only track and update referenceVideoBuffer if the client is actively dumping the DMD. I left this out as I wanted to keep the PR simple, nor did I notice any performance degradation in my testing.

Regards,
ohrn